### PR TITLE
[DEV-1483] Add `REACT_APP_` prefix to React example

### DIFF
--- a/react/.env.example
+++ b/react/.env.example
@@ -1,5 +1,5 @@
 # Required
-USERFRONT_TENANT_ID="..."
+REACT_APP_USERFRONT_TENANT_ID="..."
 USERFRONT_API_KEY="..." # Admin key
 
 # Optional

--- a/react/README.md
+++ b/react/README.md
@@ -17,7 +17,7 @@ npm install
 Add your tenant id and api key to your `.env`:
 
 ```shell
-USERFRONT_TENANT_ID="..."
+REACT_APP_USERFRONT_TENANT_ID="..."
 USERFRONT_API_KEY="..." # Admin key
 ```
 

--- a/react/src/index.js
+++ b/react/src/index.js
@@ -8,7 +8,7 @@ import reportWebVitals from './reportWebVitals';
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <UserfrontProvider tenantId={process.env.USERFRONT_TENANT_ID}>
+    <UserfrontProvider tenantId={process.env.REACT_APP_USERFRONT_TENANT_ID}>
       <App />
     </UserfrontProvider>
   </React.StrictMode>


### PR DESCRIPTION
The `REACT_APP_` is required, like in Next.js, for public environment variables.